### PR TITLE
Fix compilation issue for x64 hardware

### DIFF
--- a/Sources/CRCCalculator.swift
+++ b/Sources/CRCCalculator.swift
@@ -57,10 +57,12 @@ extension CRCCalculator {
         withUnsafeBytes(of: value.bigEndian) { append($0) }
     }
 
+    #if arch(arm64)
     @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
     public mutating func append(bigEndian value: Float16) {
         append(bigEndian: value.bitPattern)
     }
+    #endif
 
     public mutating func append(bigEndian value: Float32) {
         append(bigEndian: value.bitPattern)


### PR DESCRIPTION
As explained in [Float16](https://developer.apple.com/documentation/swift/float16) documentation, the type is only available when targetting Apple Silicon hardware.

The `@available` directive is not enough to ignore this function on x64 hardware, causing compilation errors.

This PR comes with [a twin](https://github.com/QuickBirdEng/DataKit/pull/2) on the DataKit repository